### PR TITLE
Adds httpd config files

### DIFF
--- a/ansible/roles/ewf-app-config/files/httpd/conf.d/ewf_perl.conf
+++ b/ansible/roles/ewf-app-config/files/httpd/conf.d/ewf_perl.conf
@@ -1,0 +1,51 @@
+#
+# Mod_perl incorporates a Perl interpreter into the Apache web server,
+# so that the Apache web server can directly execute Perl code.
+# Mod_perl links the Perl runtime library into the Apache web server
+# and provides an object-oriented Perl interface for Apache's C
+# language API.  The end result is a quicker CGI script turnaround
+# process, since no external Perl interpreter has to be started.
+#
+
+LoadModule perl_module modules/mod_perl.so
+#PerlModule Apache2
+#PerlModule Apache::compat
+
+PerlRequire /etc/httpd/conf/ewf_startup.pl
+PerlRequire /home/ewf/MODULES/Apache/CacheControlHeadersOutputFilter.pm
+PerlTransHandler Apache::RewriteUri
+#PerlTransHandler Apache::StripSession2
+PerlTransHandler Apache::SessionCookieAndStrip
+
+
+# Uncomment this line to globally enable warnings, which will be
+# written to the server's error log.  Warnings should be enabled
+# during the development process, but should be disabled on a
+# production server as they affect performance.
+#
+PerlWarn On
+
+# Uncomment this line to enable taint checking globally.  When Perl is
+# running in taint mode various checks are performed to reduce the
+# risk of insecure data being passed to a subshell or being used to
+# modify the filesystem.  Unfortunatly many Perl modules are not
+# taint-safe, so you should exercise care before enabling it on a
+# production server.
+#
+#PerlTaintCheck On
+
+# This will allow execution of mod_perl to compile your scripts to
+# subroutines which it will execute directly, avoiding the costly
+# compile process for most requests.
+#
+# This will allow remote server configuration reports, with the URL of
+#  http://servername/perl-status
+# Change the ".your-domain.com" to match your domain to enable.
+#
+<Location /perl-status>
+    SetHandler perl-script
+    PerlResponseHandler Apache2::Status
+    Order deny,allow
+    Deny from all
+    Allow from ors.orctel.co.uk .orctel.internal 194.75.36.231
+</Location>

--- a/ansible/roles/ewf-app-config/files/httpd/conf/ewf_startup.pl
+++ b/ansible/roles/ewf-app-config/files/httpd/conf/ewf_startup.pl
@@ -1,0 +1,196 @@
+warn "Executing ewf_startup.pl...\n";
+sleep 1;
+
+# Extend @INC if needed
+
+use lib qw(/home/ewf/MODULES /home/ewf/htdocs/efiling/handlers /home/ewf/config);
+
+# Make sure we are in a sane environment.
+$ENV{MOD_PERL} or die "not running under mod_perl!";
+
+# Place common modules here to be pre-loaded by the mod_perl enabled server
+use ModPerl::Registry;
+use Socket;
+
+### Recycle large Apache processes
+
+use Apache2::SizeLimit;
+$Apache2::SizeLimit::MAX_PROCESS_SIZE  = 90000; # 50MB
+#$Apache2::SizeLimit::MIN_SHARE_SIZE    = 9000;  # 6MB
+#$Apache2::SizeLimit::MAX_UNSHARED_SIZE = 5000;  # 5MB
+
+$Apache2::SizeLimit::CHECK_EVERY_N_REQUESTS = 90;
+
+# ----------------- MODULE --------------------
+use CGI;
+use CHData::CompanyPrefixes;
+use CHDDB::chdCtrl;
+use Common::AISHelper;
+use Common::Basket;
+use Common::CGIEngine;
+use Common::ConstString;
+use Common::CustomerHelper;
+use Common::CVTable;
+use Common::DateHelper;
+use CommonDB::accountDetails;
+use CommonDB::auth;
+use CommonDB::customer;
+use CommonDB::cvClass;
+use CommonDB::cvClassCollection;
+use CommonDB::CVConstants qw( :DEFAULT );
+use CommonDB::cvRegistry;
+use CommonDB::cvValue;
+use CommonDB::document;
+use CommonDB::DocumentSearch;
+use CommonDB::emailNotify;
+use CommonDB::GSession;
+use CommonDB::GSessionAdmin;
+use CommonDB::notification;
+use CommonDB::OrderDetail;
+use CommonDB::OrderHeader;
+use CommonDB::OrderSearch;
+use CommonDB::profileCollection;
+use Common::goBackHelper;
+use Common::Insolvency;
+use Common::KeyGen;
+use Common::navLink;
+use Common::OrderHelper;
+use Common::ScreenInfo;
+use Common::URIHelper;
+use Common::XMLMapper;
+use Data::Dumper;
+use Digest::MD5 qw(md5_hex);
+use File::Basename;
+use File::Copy;
+use HTML::Template;
+use POSIX qw(strftime);
+use Time::Local;
+use Tuxedo::Error;
+use Tuxedo::Service;
+use XML::Simple;
+
+use strict;
+use CommonDB::GSession;
+use CommonDB::cvRegistry;
+use CommonDB::CVConstants qw( :CLASS :FORMTYPE );
+
+use Framework::sessionException;
+use Framework::exception;
+
+use CompaniesHouse::Filing::UI::autoPage;
+
+use CompaniesHouse::Filing::UI::Officers::Page::AP::appointNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::AP::appointNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::Officers::Page::AP::appointCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::AP::appointCorporateSecretaryPage;
+use CompaniesHouse::Filing::UI::Officers::Page::CH::changeNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::CH::changeNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::Officers::Page::CH::changeCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::CH::changeCorporateSecretaryPage;
+use CompaniesHouse::Filing::UI::Officers::Page::TM::terminateNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::TM::terminateNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::Officers::Page::TM::terminateCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::Officers::Page::TM::terminateCorporateSecretaryPage;
+
+use CompaniesHouse::Filing::UI::Forms::JoinProofPage;
+use CompaniesHouse::Filing::UI::Forms::LeaveProofPage;
+
+
+#use CompaniesHouse::Filing::UI::AnnualReturn::Forms::TM01Confirm;
+#use CompaniesHouse::Filing::UI::AnnualReturn::Forms::TM02Confirm;
+use CompaniesHouse::Filing::UI::Forms::TM01Confirm;
+use CompaniesHouse::Filing::UI::Forms::TM02Confirm;
+use CompaniesHouse::Filing::UI::Forms::consentToActPage;
+use CompaniesHouse::Filing::UI::Forms::intermediateChangePage;
+use CompaniesHouse::Filing::UI::Forms::otherDirectorshipsPage;
+
+use CompaniesHouse::Filing::UI::Forms::appointmentListPage;
+use CompaniesHouse::Filing::UI::Forms::appointmentListTMPage;
+
+use CompaniesHouse::Filing::UI::returnAllotmentSharesPage;
+
+use CompaniesHouse::Filing::UI::StatementOfCapital::addStatementOfCapitalPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Capital::addStatementOfCapitalPageAR;
+use CompaniesHouse::Filing::UI::AnnualReturn::Capital::issuedCapitalIncreasedWarning;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Capital::issuedCapitalIncreasedWarning;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Capital::addStatementOfCapitalPageAR;
+
+#use CompaniesHouse::Filing::UI::allotmentPage;
+#use CompaniesHouse::Filing::UI::addAllotmentPage;
+use CompaniesHouse::Filing::UI::Allotment::addAllotmentPage;
+use CompaniesHouse::Filing::UI::Allotment::amendAllotmentPage;
+use CompaniesHouse::Filing::UI::Capital::addCapitalPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Capital::addCapitalPageAR;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Capital::addCapitalPageAR;
+use CompaniesHouse::Filing::UI::Capital::amendCapitalPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Capital::amendCapitalPageAR;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Capital::amendCapitalPageAR;
+use CompaniesHouse::Filing::UI::Forms::SAILPage;
+use CompaniesHouse::Filing::UI::formState;
+use CompaniesHouse::Filing::UI::Forms::registeredOfficeAddressPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::ARPage;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::ARPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::SAILPage;
+
+#use CompaniesHouse::Filing::UI::85ACT::Forms::addNaturalAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::addCorporateAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::amendNaturalAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::amendCorporateAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::terminateNaturalAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::terminateCorporateAppointmentPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::appointmentListPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::appointmentListTMPage;
+#use CompaniesHouse::Filing::UI::85ACT::Forms::288bConfirm;
+
+
+#  Action List display pages
+
+use CompaniesHouse::Filing::UI::Appointment::showAppointmentsPage;
+#use CompaniesHouse::Filing::UI::RegOffAddr::showRegisteredOfficeAddressPage;
+
+  # Annual Return forms
+  #
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::registeredOfficeAddressPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::appointNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::appointCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::appointNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::appointCorporateSecretaryPage;
+
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::changeNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::changeCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::changeNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::changeCorporateSecretaryPage;
+
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::terminateNaturalDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::terminateCorporateDirectorPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::terminateNaturalSecretaryPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::terminateCorporateSecretaryPage;
+
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::TM01Confirm;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::TM02Confirm;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::consentToActPage;
+use CompaniesHouse::Filing::UI::AnnualReturn::Forms::intermediateChangePage;
+
+# 85 Act AR Forms
+#
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Forms::membersAddressPage;
+#use CompaniesHouse::Filing::UI::85ACT::AnnualReturn::Forms::debentureAddressPage;
+
+use CompaniesHouse::Common::errorPage;
+use CompaniesHouse::Common::httpPageScript;
+use CompaniesHouse::Common::sessionManager;
+use CompaniesHouse::Common::sessionErrorPage;
+
+# Set some ENV variables for Perl
+#
+warn "Setting Orcale Environment Variables\n";
+$ENV{ORACLE_HOME}="/usr/lib/oracle/11.2/client64/";
+$ENV{LD_LIBRARY_PATH}="/usr/lib/oracle/11.2/client64/lib/";
+$ENV{TNS_ADMIN}="/usr/lib/oracle/11.2/client64/lib/";
+
+$ENV{NLS_LANG}   = "ENGLISH_UNITED KINGDOM.UTF8";
+$ENV{LC_ALL}     = "en_GB.UTF-8";
+$ENV{DBCONNECT_PING_RATE}=40;
+
+warn "ewf_startup.pl - done\n";
+1;

--- a/ansible/roles/ewf-app-config/files/httpd/conf/httpd.conf
+++ b/ansible/roles/ewf-app-config/files/httpd/conf/httpd.conf
@@ -1,0 +1,1209 @@
+#
+# Based upon the NCSA server configuration files originally by Rob McCool.
+#
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs-2.0/> for detailed information about
+# the directives.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# The configuration directives are grouped into three basic sections:
+#  1. Directives that control the operation of the Apache server process as a
+#     whole (the 'global environment').
+#  2. Directives that define the parameters of the 'main' or 'default' server,
+#     which responds to requests that aren't handled by a virtual host.
+#     These directives also provide default values for the settings
+#     of all virtual hosts.
+#  3. Settings for virtual hosts, which allow Web requests to be sent to
+#     different IP addresses or hostnames and have them handled by the
+#     same Apache server process.
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/foo.log"
+# with ServerRoot set to "/etc/httpd" will be interpreted by the
+# server as "/etc/httpd/logs/foo.log".
+#
+
+### Section 1: Global Environment
+
+#
+# The directives in this section affect the overall operation of Apache,
+# such as the number of concurrent requests it can handle or where it
+# can find its configuration files.
+#
+
+#
+# Don't give away too much information about all the subcomponents
+# we are running.  Comment out this line if you don't mind remote sites
+# finding out what major optional modules you are running
+ServerTokens Prod
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the LockFile documentation
+# (available at <URL:http://httpd.apache.org/docs-2.0/mod/core.html#lockfile>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+ServerRoot "/etc/httpd"
+
+#
+# ScoreBoardFile: File used to store internal server process information.
+# If unspecified (the default), the scoreboard will be stored in an
+# anonymous shared memory segment, and will be unavailable to third-party
+# applications.
+# If specified, ensure that no two invocations of Apache share the same
+# scoreboard file. The scoreboard file MUST BE STORED ON A LOCAL DISK.
+#
+#ScoreBoardFile run/httpd.scoreboard
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+#
+PidFile run/httpd.pid
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 120
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive Off
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 15
+
+##
+## Server-Pool Size Regulation (MPM specific)
+## 
+
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxClients: maximum number of server processes allowed to start
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule prefork.c>
+StartServers      5 
+MinSpareServers   5
+MaxSpareServers   20
+MaxClients        85
+MaxRequestsPerChild  100
+</IfModule>
+
+# worker MPM
+# StartServers: initial number of server processes to start
+# MaxClients: maximum number of simultaneous client connections
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxRequestsPerChild: maximum number of requests a server process serves
+#<IfModule worker.c>
+#StartServers         2
+#MaxClients         150
+#MinSpareThreads      2
+#MaxSpareThreads      5 
+#ThreadsPerChild      5
+#MaxRequestsPerChild  20
+
+#
+# To reduce memory usage in the worker MPM, the thread guard page
+# can be disabled, at the expense of some protection against stack
+# overflow.
+#
+#ThreadGuardArea off
+
+#</IfModule>
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, in addition to the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses (0.0.0.0)
+# e.g. "Listen 12.34.56.78:80"
+#
+# To allow connections to IPv6 addresses add "Listen [::]:80"
+#
+#Listen 192.168.60.151:80
+Listen 0.0.0.0:80
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_alias_module modules/mod_authn_alias.so
+LoadModule authn_anon_module modules/mod_authn_anon.so
+LoadModule authn_dbm_module modules/mod_authn_dbm.so
+LoadModule authn_default_module modules/mod_authn_default.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_owner_module modules/mod_authz_owner.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_dbm_module modules/mod_authz_dbm.so
+LoadModule authz_default_module modules/mod_authz_default.so
+LoadModule ldap_module modules/mod_ldap.so
+LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+LoadModule include_module modules/mod_include.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule env_module modules/mod_env.so
+LoadModule ext_filter_module modules/mod_ext_filter.so
+LoadModule mime_magic_module modules/mod_mime_magic.so
+LoadModule expires_module modules/mod_expires.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule cookietrack_module modules/mod_cookietrack.so
+#LoadModule usertrack_module modules/mod_usertrack.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule info_module modules/mod_info.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule actions_module modules/mod_actions.so
+LoadModule speling_module modules/mod_speling.so
+LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule substitute_module modules/mod_substitute.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+LoadModule cache_module modules/mod_cache.so
+LoadModule suexec_module modules/mod_suexec.so
+LoadModule disk_cache_module modules/mod_disk_cache.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule version_module modules/mod_version.so
+LoadModule apreq_module modules/mod_apreq2.so
+
+#LoadModule asis_module modules/mod_asis.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule cern_meta_module modules/mod_cern_meta.so
+#LoadModule cgid_module modules/mod_cgid.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule filter_module modules/mod_filter.so
+#LoadModule ident_module modules/mod_ident.so
+#LoadModule log_forensic_module modules/mod_log_forensic.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+
+#
+# Load config files from the config directory "/etc/httpd/conf.d".
+#
+
+#Include conf.d/ssl.conf
+Include conf.d/ewf_perl.conf
+PerlCleanupHandler Apache2::SizeLimit
+
+#
+# ExtendedStatus controls whether Apache will generate "full" status
+# information (ExtendedStatus On) or just basic information (ExtendedStatus
+# Off) when the "server-status" handler is called. The default is Off.
+#
+ExtendedStatus On
+
+### Section 2: 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+#  . On SCO (ODT 3) use "User nouser" and "Group nogroup".
+#  . On HPUX you may not be able to use shared memory as nobody, and the
+#    suggested workaround is to create a user www and use that user.
+#  NOTE that some kernels refuse to setgid(Group) or semctl(IPC_SET)
+#  when the value of (unsigned)Group is above 60000; 
+#  don't use Group #-1 on these systems!
+#
+User ewf
+Group chlservices
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin enquiries@companieshouse.gov.uk
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If this is not set to valid DNS name for your host, server-generated
+# redirections will not work.  See also the UseCanonicalName directive.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+# You will have to access it by its address anyway, and this will make 
+# redirections work in a sensible way.
+#
+ServerName REGEXREPLACE_SERVERNAME
+
+#
+# UseCanonicalName: Determines how Apache constructs self-referencing 
+# URLs and the SERVER_NAME and SERVER_PORT variables.
+# When set "Off", Apache will use the Hostname and Port supplied
+# by the client.  When set "On", Apache will use the value of the
+# ServerName directive.
+#
+UseCanonicalName Off
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/home/ewf/htdocs/efiling/"
+
+#
+# Each directory to which Apache has access can be configured with respect
+# to which services and features are allowed and/or disabled in that
+# directory (and its subdirectories). 
+#
+# First, we configure the "default" to be a very restrictive set of 
+# features.  
+#
+<Directory />
+    Options FollowSymLinks
+    AllowOverride None
+</Directory>
+
+#Include conf.d/*.conf
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# This should be changed to whatever you set DocumentRoot to.
+#
+### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ###
+
+  CookieTracking on
+  CookieDomain .companieshouse.gov.uk
+  CookieExpires "25 months"
+  CookieName "chcookie"
+
+  SetEnv SECURE_SESSION_COOKIE 1
+
+  RewriteEngine on
+
+  RewriteCond %{HTTP_HOST} ^cy\.
+  RewriteRule (.*) https://ewfv.companieshouse.gov.uk$1?lang=cy [L]
+
+  #RewriteRule ^/$ /home/ewf/htdocs/efiling/handlers/welcome #prejointincs
+  RewriteRule ^/$ /home/ewf/htdocs/efiling/handlers/seclogin
+
+#  RewriteCond %{HTTPS} off
+#  RewriteRule (.*) https://ewfv.companieshouse.gov.uk/seclogin
+  #RewriteRule (.*) https://ewf.companieshouse.gov.uk/seclogin
+
+  # Handle 'Common' Resource mapping
+  #
+  Alias /style/com/    "/home/ewf/htdocs/sitecommon/style/"
+  Alias /images/com/   "/home/ewf/htdocs/sitecommon/images/"
+  Alias /help/com/     "/home/ewf/htdocs/sitecommon/help/"
+  Alias /html/com/     "/home/ewf/htdocs/sitecommon/html/"
+  Alias /includes/com  "/home/ewf/htdocs/sitecommon/includes/"
+# web inc change below
+  Alias /scripts/com  "/home/ewf/htdocs/sitecommon/scripts/"
+  
+  # This regex is peculiar to avoid matching ../sitecommon/handlers as this
+  # needs executable permissions.
+  #
+  <Directory ~ "/home/ewf/htdocs/sitecommon/[sih][tmen].*/.*">
+    # Two levels deep.... (images/en/ for example)
+    #
+    Options Includes FollowSymLinks
+    Order allow,deny 
+    Allow from all
+  </Directory>
+  
+  <Directory ~ "/home/ewf/htdocs/sitecommon/[sih][tmen].*">
+    # One level deep.... (style/style.css for example)
+    #
+    Options Includes FollowSymLinks
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /ewfimages/ "/mnt/ha/image/ewf2/"
+  <Directory "/mnt/ha/image/ewf2/">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /ewfupload/ "/mnt/nfs/ewf/upload/"
+   <Directory "/mnt/nfs/ewf/upload/">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /errors/ "/home/ewf/htdocs/efiling/errors/"
+  <Directory "/home/ewf/htdocs/efiling/errors">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /images/ "/home/ewf/htdocs/efiling/images/"
+  <Directory "/home/ewf/htdocs/efiling/images">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /templates/ "/home/ewf/htdocs/efiling/templates/en/stdwf/"
+  <Directory "/home/ewf/htdocs/efiling/templates">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /style/ "/home/ewf/htdocs/efiling/static/style/"
+  Alias /efstyle/ "/home/ewf/htdocs/efiling/static/style/"
+  <Directory "/home/ewf/htdocs/efiling/static/style">
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /html/ "/home/ewf/htdocs/efiling/static/html/"
+  <Directory "/home/ewf/htdocs/efiling/static/html">
+    SetHandler default-handler
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /help/ "/home/ewf/htdocs/efiling/static/help/"
+  <Directory "/home/ewf/htdocs/efiling/static/help">
+    SetHandler default-handler
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+Alias /hmrc-accounts/ "/home/ewf/htdocs/efiling/static/hmrc-accounts/"
+  <Directory "/home/ewf/htdocs/efiling/static/hmrc-accounts">
+    #SetHandler default-handler
+    Order allow,deny
+    Allow from all
+   <FilesMatch "\.(?i:pdf)$">
+        ForceType application/octet-stream
+        Header set Content-Disposition attachment
+    </FilesMatch>
+  </Directory>
+
+
+  # Site Common Handlers
+  #
+#web incs two new alias match below
+AliasMatch ^.*/com-(.*)\.htc$ "/home/ewf/htdocs/sitecommon/style/$1.htc"
+AliasMatch ^.*/(.*)\.htc$ "/home/ewf/htdocs/efiling/static/style/$1.htc"
+  AliasMatch ^/com-(.*) "/home/ewf/htdocs/sitecommon/handlers/$1"
+  <Directory  "/home/ewf/htdocs/sitecommon/handlers">
+    Options Indexes Includes FollowSymLinks +ExecCGI
+    Order allow,deny
+    SetHandler perl-script
+#'    PerlFixupHandler +Apache::DB
+    PerlResponseHandler ModPerl::Registry
+    PerlOptions +ParseHeaders
+    Allow from all
+    DirectoryIndex userlogin
+  </Directory>
+
+  Alias /test-modperl "/home/ewf/htdocs/efiling/handlers/test-modperl"
+  <Directory "/home/ewf/htdocs/efiling/handlers">
+      AddDefaultCharset UTF-8
+      Options FollowSymLinks +ExecCGI Indexes
+      DirectoryIndex login
+      SetHandler perl-script
+ #'     PerlFixupHandler +Apache::DB
+      PerlResponseHandler ModPerl::Registry
+      PerlOptions +ParseHeaders
+      Order allow,deny
+      Allow from all
+      PerlOutputFilterHandler Apache::CacheControlHeadersOutputFilter
+  </Directory>
+
+    Alias / "/home/ewf/htdocs/efiling/handlers/"
+    <Directory "/home/ewf/htdocs/efiling/handlers">
+      AddDefaultCharset UTF-8
+      Options FollowSymLinks +ExecCGI Indexes
+      DirectoryIndex login
+      SetHandler perl-script
+#'      PerlFixupHandler +Apache::DB
+      PerlResponseHandler ModPerl::Registry
+      PerlOptions +ParseHeaders
+      Order allow,deny
+      Allow from all
+     # Additional Headers
+     # Header add Cache-Control "no-cache, no-store, must-revalidate"
+     # Header add Pragma "no-cache"
+     #FEB Changes
+      PerlOutputFilterHandler Apache::CacheControlHeadersOutputFilter
+
+    DirectoryIndex welcome index
+  </Directory>
+
+### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ### EWFLIVE ###
+#
+# UserDir: The name of the directory that is appended onto a user's home
+# directory if a ~user request is received.
+#
+# The path to the end user account 'public_html' directory must be
+# accessible to the webserver userid.  This usually means that ~userid
+# must have permissions of 711, ~userid/public_html must have permissions
+# of 755, and documents contained therein must be world-readable.
+# Otherwise, the client will only receive a "403 Forbidden" message.
+#
+# See also: http://httpd.apache.org/docs/misc/FAQ.html#forbidden
+#
+<IfModule mod_userdir.c>
+    #
+    # UserDir is disabled by default since it can confirm the presence
+    # of a username on the system (depending on home directory
+    # permissions).
+    #
+    UserDir disable
+
+    #
+    # To enable requests to /~user/ to serve the user's public_html
+    # directory, remove the "UserDir disable" line above, and uncomment
+    # the following line instead:
+    # 
+    #UserDir public_html
+
+</IfModule>
+
+#
+# Control access to UserDir directories.  The following is an example
+# for a site where these directories are restricted to read-only.
+#
+#<Directory /home/*/public_html>
+#    AllowOverride FileInfo AuthConfig Limit
+#    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+#    <Limit GET POST OPTIONS>
+#        Order allow,deny
+#        Allow from all
+#    </Limit>
+#    <LimitExcept GET POST OPTIONS>
+#        Order deny,allow
+#        Deny from all
+#    </LimitExcept>
+#</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+# The index.html.var file (a type-map) is used to deliver content-
+# negotiated documents.  The MultiViews Option can be used for the 
+# same purpose, but it is much slower.
+#
+# DirectoryIndex login index index.html index.html.var
+
+#
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ~ "^\.ht">
+    Order allow,deny
+    Deny from all
+</Files>
+
+#
+# TypesConfig describes where the mime.types file (or equivalent) is
+# to be found.
+#
+TypesConfig /etc/mime.types
+
+#
+# DefaultType is the default MIME type the server will use for a document
+# if it cannot otherwise determine one, such as from filename extensions.
+# If your server contains mostly text or HTML documents, "text/plain" is
+# a good value.  If most of your content is binary, such as applications
+# or images, you may want to use "application/octet-stream" instead to
+# keep browsers from trying to display binary files as though they are
+# text.
+#
+DefaultType text/plain
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+<IfModule mod_mime_magic.c>
+#   MIMEMagicFile /usr/share/magic.mime
+    MIMEMagicFile conf/magic
+</IfModule>
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+#
+# EnableMMAP: Control whether memory-mapping is used to deliver
+# files (assuming that the underlying OS supports it).
+# The default is on; turn this off if you serve from NFS-mounted 
+# filesystems.  On some systems, turning it off (regardless of
+# filesystem) can improve performance; for details, please see
+# http://httpd.apache.org/docs-2.0/mod/core.html#enablemmap
+#
+#EnableMMAP off
+
+#
+# EnableSendfile: Control whether the sendfile kernel support is 
+# used to deliver files (assuming that the OS supports it). 
+# The default is on; turn this off if you serve from NFS-mounted 
+# filesystems.  Please see
+# http://httpd.apache.org/docs-2.0/mod/core.html#enablesendfile
+#
+#EnableSendfile off
+#
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog /var/log/httpd/ewf_error_log
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive (see below).
+#
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{cookie}n\" %{pid}P" combined 
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+#
+# The location and format of the access logfile (Common Logfile Format).
+# If you do not define any access logfiles within a <VirtualHost>
+# container, they will be logged here.  Contrariwise, if you *do*
+# define per-<VirtualHost> access logfiles, transactions will be
+# logged therein and *not* in this file.
+#
+# CustomLog logs/access_log common
+CustomLog /var/log/httpd/ewf_access_log combined
+
+#
+# If you would like to have agent and referer logfiles, uncomment the
+# following directives.
+#
+#CustomLog logs/referer_log referer
+#CustomLog logs/agent_log agent
+
+#
+# If you prefer a single logfile with access, agent, and referer information
+# (Combined Logfile Format) you can use the following directive.
+#
+#CustomLog logs/access_log combined
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (error documents, FTP directory listings,
+# mod_status and mod_info output etc., but not CGI generated documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+#
+ServerSignature Off
+
+#
+# Aliases: Add here as many aliases as you need (with no limit). The format is 
+# Alias fakename realname
+#
+# Note that if you include a trailing / on fakename then the server will
+# require it to be present in the URL.  So "/icons" isn't aliased in this
+# example, only "/icons/".  If the fakename is slash-terminated, then the 
+# realname must also be slash terminated, and if the fakename omits the 
+# trailing slash, the realname must also omit it.
+#
+# We include the /icons/ alias for FancyIndexed directory listings.  If you
+# do not use FancyIndexing, you may comment this out.
+#
+#Alias /icons/ "/var/www/icons/"
+
+#<Directory "/var/www/icons">
+#    Options Indexes MultiViews
+#    AllowOverride None
+#    Order allow,deny
+#    Allow from all
+#</Directory>
+
+#
+# This should be changed to the ServerRoot/manual/.  The alias provides
+# the manual, even if you choose to move your DocumentRoot.  You may comment
+# this out if you do not care for the documentation.
+#
+#Alias /manual "/var/www/manual"
+
+#<Directory "/var/www/manual">
+#    Options Indexes FollowSymLinks MultiViews
+#    AllowOverride None
+#    Order allow,deny
+#    Allow from all
+#</Directory>
+
+<IfModule mod_dav_fs.c>
+    # Location of the WebDAV lock database.
+    DAVLockDB /var/lib/dav/lockdb
+</IfModule>
+
+#
+# ScriptAlias: This controls which directories contain server scripts.
+# ScriptAliases are essentially the same as Aliases, except that
+# documents in the realname directory are treated as applications and
+# run by the server when requested rather than as documents sent to the client.
+# The same rules about trailing "/" apply to ScriptAlias directives as to
+# Alias.
+#
+#ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+
+#
+# "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+#<Directory "/var/www/cgi-bin">
+#    AllowOverride None
+#    Options None
+#    Order allow,deny
+#    Allow from all
+#</Directory>
+
+#
+# Redirect allows you to tell clients about documents which used to exist in
+# your server's namespace, but do not anymore. This allows you to tell the
+# clients where to look for the relocated document.
+# Example:
+# Redirect permanent /foo http://www.example.com/bar
+#Release_2_2012
+RedirectMatch 301 (.*)/welcome $1/seclogin
+
+#
+# Directives controlling the display of server-generated directory listings.
+#
+
+#
+# FancyIndexing is whether you want fancy directory indexing or standard.
+# VersionSort is whether files containing version numbers should be 
+# compared in the natural way, so that `apache-1.3.9.tar' is placed before
+# `apache-1.3.12.tar'.
+#
+IndexOptions FancyIndexing VersionSort NameWidth=*
+
+#
+# AddIcon* directives tell the server which icon to show for different
+# files or filename extensions.  These are only displayed for
+# FancyIndexed directories.
+#
+#AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+
+#AddIconByType (TXT,/icons/text.gif) text/*
+#AddIconByType (IMG,/icons/image2.gif) image/*
+#AddIconByType (SND,/icons/sound2.gif) audio/*
+#AddIconByType (VID,/icons/movie.gif) video/*
+
+#AddIcon /icons/binary.gif .bin .exe
+#AddIcon /icons/binhex.gif .hqx
+#AddIcon /icons/tar.gif .tar
+#AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#AddIcon /icons/a.gif .ps .ai .eps
+#AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#AddIcon /icons/text.gif .txt
+#AddIcon /icons/c.gif .c
+#AddIcon /icons/p.gif .pl .py
+#AddIcon /icons/f.gif .for
+#AddIcon /icons/dvi.gif .dvi
+#AddIcon /icons/uuencoded.gif .uu
+#AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#AddIcon /icons/tex.gif .tex
+#AddIcon /icons/bomb.gif core
+#
+#AddIcon /icons/back.gif ..
+#AddIcon /icons/hand.right.gif README
+#AddIcon /icons/folder.gif ^^DIRECTORY^^
+#AddIcon /icons/blank.gif ^^BLANKICON^^
+
+#
+# DefaultIcon is which icon to show for files which do not have an icon
+# explicitly set.
+#
+#DefaultIcon /icons/unknown.gif
+
+#
+# AddDescription allows you to place a short description after a file in
+# server-generated indexes.  These are only displayed for FancyIndexed
+# directories.
+# Format: AddDescription "description" filename
+#
+#AddDescription "GZIP compressed document" .gz
+#AddDescription "tar archive" .tar
+#AddDescription "GZIP compressed tar archive" .tgz
+
+#
+# ReadmeName is the name of the README file the server will look for by
+# default, and append to directory listings.
+#
+# HeaderName is the name of a file which should be prepended to
+# directory indexes. 
+ReadmeName README.html
+HeaderName HEADER.html
+
+#
+# IndexIgnore is a set of filenames which directory indexing should ignore
+# and not include in the listing.  Shell-style wildcarding is permitted.
+#
+IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+
+#
+# AddEncoding allows you to have certain browsers (Mosaic/X 2.1+) uncompress
+# information on the fly. Note: Not all browsers support this.
+# Despite the name similarity, the following Add* directives have nothing
+# to do with the FancyIndexing customization directives above.
+#
+AddEncoding x-compress Z
+AddEncoding x-gzip gz tgz
+
+#
+# DefaultLanguage and AddLanguage allows you to specify the language of 
+# a document. You can then use content negotiation to give a browser a 
+# file in a language the user can understand.
+#
+# Specify a default language. This means that all data
+# going out without a specific language tag (see below) will 
+# be marked with this one. You probably do NOT want to set
+# this unless you are sure it is correct for all cases.
+#
+# * It is generally better to not mark a page as 
+# * being a certain language than marking it with the wrong
+# * language!
+#
+# DefaultLanguage nl
+#
+# Note 1: The suffix does not have to be the same as the language
+# keyword --- those with documents in Polish (whose net-standard
+# language code is pl) may wish to use "AddLanguage pl .po" to
+# avoid the ambiguity with the common suffix for perl scripts.
+#
+# Note 2: The example entries below illustrate that in some cases 
+# the two character 'Language' abbreviation is not identical to 
+# the two character 'Country' code for its country,
+# E.g. 'Danmark/dk' versus 'Danish/da'.
+#
+# Note 3: In the case of 'ltz' we violate the RFC by using a three char
+# specifier. There is 'work in progress' to fix this and get
+# the reference data for rfc1766 cleaned up.
+#
+# Danish (da) - Dutch (nl) - English (en) - Estonian (et)
+# French (fr) - German (de) - Greek-Modern (el)
+# Italian (it) - Norwegian (no) - Norwegian Nynorsk (nn) - Korean (ko) 
+# Portugese (pt) - Luxembourgeois* (ltz)
+# Spanish (es) - Swedish (sv) - Catalan (ca) - Czech(cs)
+# Polish (pl) - Brazilian Portuguese (pt-br) - Japanese (ja)
+# Russian (ru) - Croatian (hr)
+#
+AddLanguage da .dk
+AddLanguage nl .nl
+AddLanguage en .en
+AddLanguage et .et
+AddLanguage fr .fr
+AddLanguage de .de
+AddLanguage he .he
+AddLanguage el .el
+AddLanguage it .it
+AddLanguage ja .ja
+AddLanguage pl .po
+AddLanguage ko .ko
+AddLanguage pt .pt
+AddLanguage nn .nn
+AddLanguage no .no
+AddLanguage pt-br .pt-br
+AddLanguage ltz .ltz
+AddLanguage ca .ca
+AddLanguage es .es
+AddLanguage sv .sv
+AddLanguage cs .cz .cs
+AddLanguage ru .ru
+AddLanguage zh-CN .zh-cn
+AddLanguage zh-TW .zh-tw
+AddLanguage hr .hr
+
+#
+# LanguagePriority allows you to give precedence to some languages
+# in case of a tie during content negotiation.
+#
+# Just list the languages in decreasing order of preference. We have
+# more or less alphabetized them here. You probably want to change this.
+#
+LanguagePriority en da nl et fr de el it ja ko no pl pt pt-br ltz ca es sv tw
+
+#
+# ForceLanguagePriority allows you to serve a result page rather than
+# MULTIPLE CHOICES (Prefer) [in case of a tie] or NOT ACCEPTABLE (Fallback)
+# [in case no accepted languages matched the available variants]
+#
+ForceLanguagePriority Prefer Fallback
+
+#
+# Specify a default charset for all pages sent out. This is
+# always a good idea and opens the door for future internationalisation
+# of your web site, should you ever want it. Specifying it as
+# a default does little harm; as the standard dictates that a page
+# is in iso-8859-1 (latin1) unless specified otherwise i.e. you
+# are merely stating the obvious. There are also some security
+# reasons in browsers, related to javascript and URL parsing
+# which encourage you to always set a default char set.
+#
+AddDefaultCharset UTF-8
+
+#
+# Commonly used filename extensions to character sets. You probably
+# want to avoid clashes with the language extensions, unless you
+# are good at carefully testing your setup after each change.
+# See http://www.iana.org/assignments/character-sets for the
+# official list of charset names and their respective RFCs
+#
+AddCharset ISO-8859-1  .iso8859-1  .latin1
+AddCharset ISO-8859-2  .iso8859-2  .latin2 .cen
+AddCharset ISO-8859-3  .iso8859-3  .latin3
+AddCharset ISO-8859-4  .iso8859-4  .latin4
+AddCharset ISO-8859-5  .iso8859-5  .latin5 .cyr .iso-ru
+AddCharset ISO-8859-6  .iso8859-6  .latin6 .arb
+AddCharset ISO-8859-7  .iso8859-7  .latin7 .grk
+AddCharset ISO-8859-8  .iso8859-8  .latin8 .heb
+AddCharset ISO-8859-9  .iso8859-9  .latin9 .trk
+AddCharset ISO-2022-JP .iso2022-jp .jis
+AddCharset ISO-2022-KR .iso2022-kr .kis
+AddCharset ISO-2022-CN .iso2022-cn .cis
+AddCharset Big5        .Big5       .big5
+# For russian, more than one charset is used (depends on client, mostly):
+AddCharset WINDOWS-1251 .cp-1251   .win-1251
+AddCharset CP866       .cp866
+AddCharset KOI8-r      .koi8-r .koi8-ru
+AddCharset KOI8-ru     .koi8-uk .ua
+AddCharset ISO-10646-UCS-2 .ucs2
+AddCharset ISO-10646-UCS-4 .ucs4
+AddCharset UTF-8       .utf8
+
+# The set below does not map to a specific (iso) standard
+# but works on a fairly wide range of browsers. Note that
+# capitalization actually matters (it should not, but it
+# does for some browsers).
+#
+# See http://www.iana.org/assignments/character-sets
+# for a list of sorts. But browsers support few.
+#
+AddCharset GB2312      .gb2312 .gb 
+AddCharset utf-7       .utf7
+AddCharset utf-8       .utf8
+AddCharset big5        .big5 .b5
+AddCharset EUC-TW      .euc-tw
+AddCharset EUC-JP      .euc-jp
+AddCharset EUC-KR      .euc-kr
+AddCharset shift_jis   .sjis
+
+#
+# AddType allows you to add to or override the MIME configuration
+# file mime.types for specific file types.
+#
+AddType application/x-tar .tgz
+
+#
+# AddHandler allows you to map certain file extensions to "handlers":
+# actions unrelated to filetype. These can be either built into the server
+# or added with the Action directive (see below)
+#
+# To use CGI scripts outside of ScriptAliased directories:
+# (You will also need to add "ExecCGI" to the "Options" directive.)
+#
+#AddHandler cgi-script .cgi
+
+#
+# For files that include their own HTTP headers:
+#
+AddHandler send-as-is asis
+
+#
+# For server-parsed imagemap files:
+#
+AddHandler imap-file map
+
+#
+# For type maps (negotiated resources):
+# (This is enabled by default to allow the Apache "It Worked" page
+#  to be distributed in multiple languages.)
+#
+AddHandler type-map var
+
+# Filters allow you to process content before it is sent to the client.
+#
+# To parse .shtml files for server-side includes (SSI):
+# (You will also need to add "Includes" to the "Options" directive.)
+#
+# added as per ewfpreprodtest for web incs
+AddType text/html .shtml
+AddOutputFilter INCLUDES .shtml
+#web inc change below
+AddType text/x-component .htc
+
+#
+# Action lets you define media types that will execute a script whenever
+# a matching file is called. This eliminates the need for repeated URL
+# pathnames for oft-used CGI file processors.
+# Format: Action media/type /cgi-script/location
+# Format: Action handler-name /cgi-script/location
+#
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# Putting this all together, we can Internationalize error responses.
+#
+# We use Alias to redirect any /error/HTTP_<error>.html.var response to
+# our collection of by-error message multi-language collections.  We use 
+# includes to substitute the appropriate text.
+#
+# You can modify the messages' appearance without changing any of the
+# default HTTP_<error>.html.var files by adding the line;
+#
+#   Alias /error/include/ "/your/include/path/"
+#
+# which allows you to create your own set of files by starting with the
+# /var/www/error/include/ files and
+# copying them to /your/include/path/, even on a per-VirtualHost basis.
+#
+
+#Alias /error/ "/var/www/error/"
+
+<IfModule mod_negotiation.c>
+<IfModule mod_include.c>
+    <Directory "/var/www/error">
+        AllowOverride None
+        Options IncludesNoExec
+        AddOutputFilter Includes html
+        AddHandler type-map var
+        Order allow,deny
+        Allow from all
+        LanguagePriority en es de fr
+        ForceLanguagePriority Prefer Fallback
+    </Directory>
+
+#    ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
+#    ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
+#    ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
+#    ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
+#    ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
+#    ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
+#    ErrorDocument 410 /error/HTTP_GONE.html.var
+#    ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
+#    ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
+#    ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
+#    ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
+#    ErrorDocument 415 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+#    ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
+#    ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
+#    ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
+#    ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+#    ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+
+</IfModule>
+</IfModule>
+
+#
+# The following directives modify normal HTTP response behavior to
+# handle known problems with browser implementations.
+#
+BrowserMatch "Mozilla/2" nokeepalive
+BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
+BrowserMatch "RealPlayer 4\.0" force-response-1.0
+BrowserMatch "Java/1\.0" force-response-1.0
+BrowserMatch "JDK/1\.0" force-response-1.0
+
+#
+# The following directive disables redirects on non-GET requests for
+# a directory that does not include the trailing slash.  This fixes a 
+# problem with Microsoft WebFolders which does not appropriately handle 
+# redirects for folders with DAV methods.
+# Same deal with Apple's DAV filesystem and Gnome VFS support for DAV.
+#
+BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
+BrowserMatch "^WebDrive" redirect-carefully
+BrowserMatch "^WebDAVFS/1.[012]" redirect-carefully
+BrowserMatch "^gnome-vfs" redirect-carefully
+
+#
+# Allow server status reports, with the URL of http://servername/server-status
+# Change the ".your-domain.com" to match your domain to enable.
+#
+<Location /server-status>
+    SetHandler server-status
+    Order deny,allow
+    Deny from all
+    Allow from 172.19.0.0/12
+</Location>
+
+#
+# Allow remote server configuration reports, with the URL of
+#  http://servername/server-info (requires that mod_info.c be loaded).
+# Change the ".example.com" to match your domain to enable.
+#
+<Location /server-info>
+    SetHandler server-info
+    Order deny,allow
+    Deny from all
+    Allow from 172.19.0.0/12
+</Location>
+
+#
+# Proxy Server directives. Uncomment the following lines to
+# enable the proxy server:
+#
+#<IfModule mod_proxy.c>
+#ProxyRequests On
+#
+#<Proxy *>
+#    Order deny,allow
+#    Deny from all
+#    Allow from .example.com
+#</Proxy>
+
+#
+# Enable/disable the handling of HTTP/1.1 "Via:" headers.
+# ("Full" adds the server version; "Block" removes all outgoing Via: headers)
+# Set to one of: Off | On | Full | Block
+#
+#ProxyVia On
+
+#
+# To enable a cache of proxied content, uncomment the following lines.
+# See http://httpd.apache.org/docs-2.0/mod/mod_cache.html for more details.
+#
+#<IfModule mod_disk_cache.c>
+#   CacheEnable disk /
+#   CacheRoot "/var/cache/mod_proxy"
+#</IfModule>
+#
+
+#</IfModule>
+# End of proxy directives.
+
+### Section 3: Virtual Hosts
+#
+# VirtualHost: If you want to maintain multiple domains/hostnames on your
+# machine you can setup VirtualHost containers for them. Most configurations
+# use only name-based virtual hosts so the server doesn't need to worry about
+# IP addresses. This is indicated by the asterisks in the directives below.
+#
+# Please see the documentation at 
+# <URL:http://httpd.apache.org/docs-2.0/vhosts/>
+# for further details before you try to setup virtual hosts.
+#
+# You may use the command line option '-S' to verify your virtual host
+# configuration.
+
+#
+# Use name-based virtual hosting.
+#
+#NameVirtualHost *:80
+
+#
+# VirtualHost example:
+# Almost any Apache directive may go into a VirtualHost container.
+# The first VirtualHost section is used for requests without a known
+# server name.
+#
+#<VirtualHost *>
+#    ServerAdmin webmaster@dummy-host.example.com
+#    DocumentRoot /www/docs/dummy-host.example.com
+#    ServerName dummy-host.example.com
+#    ErrorLog logs/dummy-host.example.com-error_log
+#    CustomLog logs/dummy-host.example.com-access_log common
+#</VirtualHost>
+
+TraceEnable off

--- a/ansible/roles/ewf-app-config/tasks/main.yml
+++ b/ansible/roles/ewf-app-config/tasks/main.yml
@@ -16,3 +16,15 @@
     path: "{{ item.path }}"
     state: absent
   with_items: "{{ files_to_delete.files }}"
+
+- name: Install httpd configs
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/{{ item }}"
+    owner: ewf
+    group: chlservices
+    mode: 0775
+  with_items:
+    - httpd/conf.d/ewf_perl.conf
+    - httpd/conf/ewf_startup.pl
+    - httpd/conf/httpd.conf


### PR DESCRIPTION
Adds the current EWF httpd config files while renaming 'ewflive' to 'ewf' to make things generic.

The only value that needs to be replaced by Terraform at this point is the `ServerName` in `httpd.conf`. The current value is set to `REGEXREPLACE_SERVERNAME` so we can hook on to it and replace as needed.