### PR TITLE
Adding httpd check back in, update to latest nrpe role removes command registration

### DIFF
--- a/ansible/host_vars/ewf-frontend.yaml
+++ b/ansible/host_vars/ewf-frontend.yaml
@@ -64,6 +64,10 @@ nrpe_command:
     sudo: true
     script: check_service.sh
     option: $ARG1$
+  check_httpd:
+    sudo: true
+    script: check_service.sh
+    option: $ARG1$
   check_syslogd:
     sudo: true
     script: check_service.sh

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,7 +4,7 @@ collections:
     version: 0.1.36
     type: git
   - name: git@github.com:companieshouse/ansible-collections.git#/ch_collections/heritage_services
-    version: 0.1.57
+    version: 0.1.58
     type: git
 
   - name: ansible.posix


### PR DESCRIPTION
Adding httpd check back in, update to latest nrpe role removes command registration so these commands are only added to the commands.cfg file now so will be ignored if not applied at Nagios level