### PR TITLE
Update Matomo Template creation task

### DIFF
--- a/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
+++ b/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
@@ -75,9 +75,7 @@
         loop: "{{ config_files }}"
 
       - name: Create Matomo templates
-        shell: perl -I {{ home_dir }}/config/ {{ home_dir }}/htdocs/efiling/templates/tracker.pl
-        args:
-          creates: "{{ home_dir }}/htdocs/efiling/templates/tracker.pl"
+        command: perl -I {{ home_dir }}/config/ {{ home_dir }}/htdocs/efiling/templates/tracker.pl
 
       - name: Cleanup install files
         file:

--- a/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
+++ b/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
@@ -75,7 +75,7 @@
         loop: "{{ config_files }}"
 
       - name: Create Matomo templates
-        command: perl -I {{ home_dir }}/config/ {{ home_dir }}/htdocs/efiling/templates/tracker.pl
+        shell: perl -I {{ home_dir }}/config/ {{ home_dir }}/htdocs/efiling/templates/tracker.pl
         args:
           creates: "{{ home_dir }}/htdocs/efiling/templates/tracker.pl"
 


### PR DESCRIPTION
Removed `creates` arg from Matomo template creation task as the command is not responsible for creating the file that was specified.