### PR TITLE
Add correct ownership to config/My directories

### DIFF
--- a/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
+++ b/ansible/roles/ewf-app-config/files/deployment-scripts/frontend_deployment.yml
@@ -56,6 +56,8 @@
           path: "{{ home_dir }}/config/My"
           state: directory
           recurse: yes
+          owner: "{{ home_dir | basename }}"
+          group: chlservices
           mode: '0755'
 
       - name: Download environment config files from S3


### PR DESCRIPTION
Updated frontend deployment script to ensure `config/My` is created with correct ownership